### PR TITLE
Fix: Unmute audio when increasing volume from mute state

### DIFF
--- a/volume_scroller@francislavoie.github.io/extension.js
+++ b/volume_scroller@francislavoie.github.io/extension.js
@@ -71,6 +71,9 @@ export default class VolumeScrollerExtension extends Extension {
     const multiplier = this.direction ? -1 : 1;
     switch (event.get_scroll_direction()) {
       case Clutter.ScrollDirection.UP:
+        if (this.sink.is_muted) {
+          this.sink.change_is_muted(false);
+        }
         volume += this._get_step() * multiplier;
         break;
 


### PR DESCRIPTION
This PR fixes an issue where scrolling up to increase volume did not automatically unmute the system when it was muted.
## Changes:

    Added a check in _handle_scroll to detect if the sink is muted.
    If muted, the extension now calls this.sink.change_is_muted(false) before modifying the volume.
    Ensures a smoother user experience by restoring volume functionality after accidental mutes.

## Testing:

    Mute the system volume.
    Scroll up to increase the volume.
    Verify that the system automatically unmutes and the volume increases as expected.

## Why this is needed:

Without this fix, users must manually unmute before adjusting the volume, which can be inconvenient. This makes volume control more intuitive.