### PR TITLE
Fix port label cause OSD not to show

### DIFF
--- a/volume_scroller@francislavoie.github.io/extension.js
+++ b/volume_scroller@francislavoie.github.io/extension.js
@@ -144,8 +144,9 @@ export default class VolumeScrollerExtension extends Extension {
       : Math.clamp(Math.floor(3 * percentage + 1), 1, 3);
 
     const icon = Gio.Icon.new_for_string(VolumeScrollerIcons[iconIndex]);
-    const label = this.sink.get_port().human_port;
-    
+    const port = this.sink.get_port();
+    const label = port ? port.human_port : this.sink.get_description();
+
     // GNOME version
     const [major] = Config.PACKAGE_VERSION.split('.').map(Number);
 


### PR DESCRIPTION
The volume OSD (On-Screen Display) doesn't appear when adjusting the volume. This happens because this.sink.get_port() returns null for some audio configurations (e.g.,  when using pro profile)

this fixes it

```diff
-    const label = this.sink.get_port().human_port;
+    const port = this.sink.get_port();
+    const label = port ? port.human_port : this.sink.get_description();
```
